### PR TITLE
Removing also hardhat since deploy requires types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "GPL-3.0-only",
   "scripts": {
     "chain": "npx hardhat node",
-    "clean": "rimraf ./lib && rimraf ./types",
+    "clean": "rimraf ./lib && rimraf ./types && rimraf ./hardhat",
     "build": "yarn clean && yarn build:sol && tsc && mkdir -p ./lib/chain && cp -R ./chain/abis ./lib/chain/abis",
     "build:sol": "hardhat compile && hardhat extract",
     "test": "hardhat test --no-compile --network hardhat",


### PR DESCRIPTION
`clean` remove types but not hardhat, so recompilation fails as it runs `tsc` which relies on `types` that will not be regenerated due to `hardhat` cache.