### PR TITLE
Set private key for alice when using hardhat

### DIFF
--- a/deploy/040_HOPRBoost-minting.ts
+++ b/deploy/040_HOPRBoost-minting.ts
@@ -1,7 +1,7 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { BADGES } from "../utils/constants";
-import { HoprBoost } from "../lib/types/HoprBoost"
+import { BADGES, PRIVATE_KEY_ALICE } from "../utils/constants";
+import { HoprBoost } from "../lib/types/HoprBoost";
 
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, ethers } = hre;
@@ -12,8 +12,10 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // We obtain the just deployed HoprBoost contract address based on the tx
   const boostContract = await ethers.getContractAt("HoprBoost", HoprBoost.address) as HoprBoost;
 
-  // We mint a single NFT to alice, and pass the proper values
-  const mintTx = await boostContract
+  console.log(`Private key of target account used for minted NFTs: ${PRIVATE_KEY_ALICE}`);
+
+  // We mint a first NFT to alice, and pass the proper values
+  const mintTx1 = await boostContract
     .connect(await ethers.getSigner(admin))
     .mint(
       alice,
@@ -23,10 +25,26 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       BADGES[0].deadline
     );
 
-  await mintTx.wait()
+  await mintTx1.wait()
 
   // We log the transaction hash and verify the NFTs from the contract
-  console.log(`${admin} minted NFT in the ${mintTx.hash} transaction`);
+  console.log(`${admin} minted 1st NFT in the ${mintTx1.hash} transaction`);
+
+  // We mint a second NFT of different type to alice, and pass the proper values
+  const mintTx2 = await boostContract
+    .connect(await ethers.getSigner(admin))
+    .mint(
+      alice,
+      BADGES[2].type,
+      BADGES[2].rank,
+      BADGES[2].nominator,
+      BADGES[2].deadline
+    );
+
+  await mintTx2.wait()
+
+  // We log the transaction hash and verify the NFTs from the contract
+  console.log(`${admin} minted 2nd NFT in the ${mintTx2.hash} transaction`);
 
   // We obtain the nomiator and deadline to log them later and verify them
   const [nominator, deadline] = await boostContract.boostOf(ethers.constants.Zero);

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -10,6 +10,8 @@ import "@nomiclabs/hardhat-etherscan";
 import "@nomiclabs/hardhat-solhint";
 import "solidity-coverage";
 
+import { PRIVATE_KEY_ALICE } from "./utils/constants";
+
 const { ETHERSCAN , MINTER_KEY, DEPLOYER_PRIVATE_KEY } = process.env;
 
 const hardhatConfig: HardhatUserConfig = {
@@ -47,7 +49,7 @@ const hardhatConfig: HardhatUserConfig = {
       "xdai": '0xE9131488563776DE7FEa238d6112c5dA46be9a9F'
     },
     alice: {
-      default: 2,
+      default: `privateKey://${PRIVATE_KEY_ALICE}`,
       "goerli": '0x3dA21EB3D7d40fEA6bd78c627Cc9B1F59E7481E1',
       "xdai": '0x3dA21EB3D7d40fEA6bd78c627Cc9B1F59E7481E1'
     }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -2,6 +2,8 @@ import { utils } from "ethers";
 
 export const MINTER_ROLE = utils.keccak256(utils.toUtf8Bytes("MINTER_ROLE"));
 
+export const PRIVATE_KEY_ALICE = "a0a850122d32bb667999d3cf63a0bddc208cee19e2fefa3d0bd495f5fac51ec6";
+
 export const NAME = "HOPR Boost NFT";
 export const SYMBOL = "HOPR Boost";
 export const BASIC_START = 1627387200; // July 27 2021 14:00 CET.


### PR DESCRIPTION
This is useful when trying to use the account in a local setup manually.